### PR TITLE
fix for "field type conflict" error when importing back to influxdb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN addgroup -S awair && adduser -S awair -G awair
 
 # One of the Python packages has a dependency on gcc to install
 # https://github.com/closeio/ciso8601/issues/98
-RUN apk add build-base 
+RUN apk add --no-cache build-base
 
 USER awair
 

--- a/awair.py
+++ b/awair.py
@@ -66,10 +66,14 @@ class AwairConnector:
                 data = await device.air_data_five_minute(fahrenheit=False, from_date=from_time, to_date=to_time, limit=limit)
 
                 for datum in data:
-                    sensorsDict = {sensor: value for sensor, value in datum.sensors.items()}
+                    # Explicit float cast: sometimes awair will return data as integer instead of float which will
+                    # cause error "field type conflict" when importing back to influxdb
+
+                    sensorsDict = {sensor: (float)(value) for sensor, value in datum.sensors.items()}
                     if datum.score == 0:
                         continue  # gaps in reported metrics result in score 0 instead of missing record
-                    sensorsDict["score"] = datum.score
+
+                    sensorsDict["score"] = (float)(datum.score)
                     records.append({"measurement": measurement, "tags": {"host": device.uuid}, "fields": sensorsDict, "time": datum.timestamp})
 
             return records


### PR DESCRIPTION
example of error pre-changes:
```
2022-08-15 09:22:16,959 - influxdb_client.client.write_api - ERROR - The batch item wasn't processed successfully because: (422)
Reason: Unprocessable Entity
HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json; charset=utf-8', 'X-Influxdb-Build': 'OSS', 'X-Influxdb-Version': 'v2.2.0', 'X-Platform-Error-Code': 'unprocessable entity', 'Date': 'Mon, 15 Aug 2022 16:22:16 GMT', 'Content-Length': '245'})
HTTP response body: {"code":"unprocessable entity","message":"failure writing points to database: partial write: field type conflict: input field \"volatile_organic_compounds\" on measurement \"air_quality\" is type integer, already exists as type float dropped=1"}
```